### PR TITLE
Update homepage impact stats

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -276,7 +276,7 @@ export const Home = () => {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div className="text-center">
               <Users className="w-8 h-8 mx-auto mb-4" />
-              <h3 className="text-4xl font-bold mb-2">200K+</h3>
+              <h3 className="text-4xl font-bold mb-2">285K+</h3>
               <p className="text-zinc-400">Ministered To</p>
             </div>
             <div className="text-center">
@@ -302,24 +302,24 @@ export const Home = () => {
               <Church className="w-12 h-12 mx-auto mb-6" />
               <h3 className="text-2xl font-bold mb-4">Churches Built</h3>
               <div className="flex items-center justify-center gap-2 text-4xl font-bold">
-                <span className="text-white">5</span>
+                <span className="text-white">7</span>
                 <span className="text-zinc-500">/</span>
                 <span className="text-zinc-500">100</span>
               </div>
               <div className="w-full bg-zinc-800 h-2 rounded-full mt-4">
-                <div className="bg-white h-full rounded-full" style={{ width: '10%' }}></div>
+                <div className="bg-white h-full rounded-full" style={{ width: '7%' }}></div>
               </div>
             </div>
             <div className="bg-zinc-900 rounded-lg p-8 text-center">
               <Users2 className="w-12 h-12 mx-auto mb-6" />
               <h3 className="text-2xl font-bold mb-4">People Reached</h3>
               <div className="flex items-center justify-center gap-2 text-4xl font-bold">
-                <span className="text-white">200,000</span>
+                <span className="text-white">285,000</span>
                 <span className="text-zinc-500">/</span>
                 <span className="text-zinc-500">1M</span>
               </div>
               <div className="w-full bg-zinc-800 h-2 rounded-full mt-4">
-                <div className="bg-white h-full rounded-full" style={{ width: '10%' }}></div>
+                <div className="bg-white h-full rounded-full" style={{ width: '28.5%' }}></div>
               </div>
             </div>
           </div>

--- a/src/pages/campaigns/WellsBuilt.tsx
+++ b/src/pages/campaigns/WellsBuilt.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { Droplets, Heart, MapPin, Book } from 'lucide-react';
 
 export const WellsBuilt = () => {
-  const wellsBuilt = 2;
+  const wellsBuilt = 5;
   const wellsGoal = 200;
   const costPerWell = 500;
   const progress = wellsBuilt / wellsGoal;

--- a/src/utils/getAllCampaigns.ts
+++ b/src/utils/getAllCampaigns.ts
@@ -6,23 +6,23 @@ export const getAllCampaigns = async (): Promise<Campaign[]> => {
     {
       id: '1',
       title: 'Churches Built',
-      description: 'Help us build 100 churches. We have built 5 so far!',
+      description: 'Help us build 100 churches. We have built 7 so far!',
       image: '/church-building.jpg',
       date: '2025-01-01',
-      progress: 0.05,
+      progress: 0.07,
       goal: '100 Churches',
-      current: '5 Churches',
+      current: '7 Churches',
       slug: 'churches',
     },
     {
       id: '2',
       title: 'People Reached',
-      description: 'Our goal is to reach 1 million people. 200,000 reached so far!',
+      description: 'Our goal is to reach 1 million people. 285,000 reached so far!',
       image: '/brazil-crowd.jpg',
       date: '2025-01-01',
-      progress: 0.2,
+      progress: 0.285,
       goal: '1M People',
-      current: '200,000 People',
+      current: '285,000 People',
       slug: 'people',
     },
     {
@@ -31,10 +31,10 @@ export const getAllCampaigns = async (): Promise<Campaign[]> => {
       description: 'Build wells in Pakistan for $500 each. Clean water + the Gospel!',
       image: '/pakistan-well.jpg',
       date: '2026-01-01',
-      progress: 0.01,
+      progress: 0.025,
       goal: '200 Wells',
-      current: '2 Wells',
+      current: '5 Wells',
       slug: 'wells',
     },
   ];
-}; 
+};


### PR DESCRIPTION
## Summary
- Increase people reached from 200,000 to 285,000 across homepage and campaign data
- Increase churches built from 5 to 7 across homepage and campaign data
- Increase wells built from 2 to 5 across campaign data and the wells detail page

## Verification
- npm run lint
- npm run build

Ragu will review afterward.