### PR TITLE
Update Missions page Honduras funding

### DIFF
--- a/src/pages/Missions.tsx
+++ b/src/pages/Missions.tsx
@@ -19,24 +19,6 @@ interface Trip {
 
 const upcomingTrips: Trip[] = [
   {
-    id: 'brazil-2026',
-    country: 'Brazil',
-    flag: '🇧🇷',
-    title: 'Brazil Crusade',
-    date: 'May 2026',
-    description: 'Return to Brazil for another powerful crusade. We\'re believing for thousands to encounter Jesus and lives to be forever changed.',
-    highlights: [
-      'Large-scale evangelistic event',
-      'Youth conference',
-      'Worship & ministry nights',
-      'Leadership training',
-    ],
-    cta: 'Partner With Us',
-    ctaLink: '/donate',
-    fundingCurrent: 35000,
-    fundingGoal: 75000,
-  },
-  {
     id: 'honduras-2026',
     country: 'Honduras',
     flag: '🇭🇳',
@@ -52,7 +34,7 @@ const upcomingTrips: Trip[] = [
     cta: 'Sign Up Now',
     ctaLink: 'https://dreamon.gomethod.app/!/56456/honduras-coffee-missions-trip',
     external: true,
-    fundingCurrent: 0,
+    fundingCurrent: 2000,
     fundingGoal: 10000,
   },
 ];


### PR DESCRIPTION
## Summary
- Remove Brazil from the active Missions page trip list
- Update Honduras funding progress to `$2,000 of $10,000`

## Validation
- `npm run build` passed

Notes: `npm ci` was needed first because `nx` was not installed locally. The install reported existing audit vulnerabilities, but completed successfully.